### PR TITLE
Fix script-exporter release

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -17,4 +17,5 @@ jobs:
     uses: canonical/observability/.github/workflows/charm-promote.yaml@v0
     with:
       promotion: ${{ github.event.inputs.promotion }}
+      provider: machine
     secrets: inherit


### PR DESCRIPTION
By default the promote action will use microk8s as provider. Script Exporter is a machine charm, so it needs to have machine provider