### PR TITLE
feat: move binary dependency from runtime to pack‑time and add arm64 support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -30,6 +30,14 @@ parts:
       craftctl default
       git describe --always > $CRAFT_PART_INSTALL/version
 
+  script-exporter-binary:
+    plugin: dump
+    source: https://github.com/ricoberger/script_exporter/releases/download/v2.15.1/script_exporter-linux-${CRAFT_ARCH_BUILD_FOR}
+    source-type: file
+    permissions:
+      - path: script_exporter-linux-${CRAFT_ARCH_BUILD_FOR}
+        mode: "755"
+
 resources:
   script-exporter-binary:
     type: file

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,8 +17,11 @@ subordinate: true
 
 platforms:
   ubuntu@20.04:amd64:
+  ubuntu@20.04:arm64:
   ubuntu@22.04:amd64:
+  ubuntu@22.04:arm64:
   ubuntu@24.04:amd64:
+  ubuntu@24.04:arm64:
 
 parts:
   charm:

--- a/src/charm.py
+++ b/src/charm.py
@@ -81,7 +81,8 @@ class ScriptExporterCharm(ops.CharmBase):
 
     def _on_start(self, _: ops.StartEvent):
         """Handle start event."""
-        service_restart(SERVICE_FILENAME)
+        if not service_running(SERVICE_FILENAME) and self.model.config["config_file"]:
+            service_restart(SERVICE_FILENAME)
 
     def _on_stop(self, _: ops.StopEvent):
         """Ensure that script exporter is stopped."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -38,7 +38,7 @@ EXPORTER_PORT = 9469
 ARCH = platform.machine()
 if platform.machine() == "x86_64":
     ARCH = "amd64"
-elif platform.machine() in ("aarch64", "arm64", "armv8b", "armv8l"):
+elif platform.machine() in ("aarch64", "armv8b", "armv8l"):
     ARCH = "arm64"
 
 


### PR DESCRIPTION
This PR moves the binary dependency from runtime to pack-time, and adds arm64.

Fixes #41.

Drive-by: do not attempt to restart the service if the config file was not provided. Fixes #8.

## Testing
Tested manually on arm64 with the following bundle:

```yaml
default-base: ubuntu@24.04/stable
applications:
  se20:
    charm: ./script-exporter_ubuntu@20.04-arm64.charm
    base: ubuntu@20.04/stable
    options:
      config_file: |
        scripts:
          - name: hello
            command: /etc/script-exporter-script
            args:
              - argument
      prometheus_config_file: |
        scrape_configs:
          - job_name: 'script_helloworld'
            metrics_path: /probe
            params:
              script: [hello]
              prefix: [script]
            static_configs:
              - targets:
                - 127.0.0.1
  se22:
    charm: ./script-exporter_ubuntu@22.04-arm64.charm
    base: ubuntu@22.04/stable
    options:
      config_file: |
        scripts:
          - name: hello
            command: /etc/script-exporter-script
            args:
              - argument
      prometheus_config_file: |
        scrape_configs:
          - job_name: 'script_helloworld'
            metrics_path: /probe
            params:
              script: [hello]
              prefix: [script]
            static_configs:
              - targets:
                - 127.0.0.1
  se24:
    charm: ./script-exporter_ubuntu@24.04-arm64.charm
    options:
      config_file: |
        scripts:
          - name: hello
            command: /etc/script-exporter-script
            args:
              - argument
      prometheus_config_file: |
        scrape_configs:
          - job_name: 'script_helloworld'
            metrics_path: /probe
            params:
              script: [hello]
              prefix: [script]
            static_configs:
              - targets:
                - 127.0.0.1
  ub20:
    charm: ubuntu
    channel: latest/stable
    revision: 26
    base: ubuntu@20.04/stable
    num_units: 1
    to:
    - "0"
    constraints: arch=arm64
    storage:
      block: loop,100M
      files: rootfs,100M
  ub22:
    charm: ubuntu
    channel: latest/stable
    revision: 26
    base: ubuntu@22.04/stable
    num_units: 1
    to:
    - "1"
    constraints: arch=arm64
    storage:
      block: loop,100M
      files: rootfs,100M
  ub24:
    charm: ubuntu
    channel: latest/stable
    revision: 26
    num_units: 1
    to:
    - "2"
    constraints: arch=arm64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "0":
    constraints: arch=arm64
    base: ubuntu@20.04/stable
  "1":
    constraints: arch=arm64
    base: ubuntu@22.04/stable
  "2":
    constraints: arch=arm64
relations:
- - ub20:juju-info
  - se20:juju-info
- - ub22:juju-info
  - se22:juju-info
- - ub24:juju-info
  - se24:juju-info
```