### PR TITLE
Remove the file resource

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -41,12 +41,6 @@ parts:
       - path: script_exporter-linux-${CRAFT_ARCH_BUILD_FOR}
         mode: "755"
 
-resources:
-  script-exporter-binary:
-    type: file
-    description: Binary for Script Exporter
-    filename: script_exporter
-
 provides:
   cos-agent:
     interface: cos_agent


### PR DESCRIPTION
In #42 we obtain the script exporter binary at pack time.
For an air-gapped env, this means that no download will be needed.
This also means we don't _need_ to keep the file resource.

In this PR the file resource is removed.
This removes the option of side-loading a custom binary to the charm.
This is similar to the approach we take with k8s charms, where the charm is expected to be run with one particular oci image version.