### PR TITLE
fix: make `prometheus_config_file` config optional

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -110,11 +110,6 @@ class ScriptExporterCharm(ops.CharmBase):
         if not self.model.config["config_file"]:
             self._statuses.append(BlockedStatus('Please set the "config_file" config variable'))
 
-        elif not self.model.config["prometheus_config_file"]:
-            self._statuses.append(
-                BlockedStatus('Please set the "prometheus_config_file" config variable')
-            )
-
         for status in self._statuses:
             event.add_status(status)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -90,10 +90,9 @@ def test_status_no_config_file(ctx):
 @patch("charm.service_restart", MagicMock(return_value=True))
 def test_status_no_prometheus_config_file(ctx):
     state = State(config={"prometheus_config_file": "",
-                           "config_file": EXAMPLE_SIMPLE_CONFIG,
-                           #"scripts_archive": EXAMPLE_B64_COMPRESSED_SCRIPTS
-                           "script_file": EXAMPLE_SIMPLE_SCRIPT
-                           })
+                  "config_file": EXAMPLE_SIMPLE_CONFIG,
+                  "script_file": EXAMPLE_SIMPLE_SCRIPT
+                  })
     with patch("charm.ScriptExporterCharm._create_systemd_service", MagicMock(return_value=None)):
       state_out = ctx.run(ctx.on.config_changed(), state=state)
       assert state_out.unit_status.name == "active"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -89,9 +89,14 @@ def test_status_no_config_file(ctx):
 
 @patch("charm.service_restart", MagicMock(return_value=True))
 def test_status_no_prometheus_config_file(ctx):
-    state = State(config={"config_file": ""})
-    state_out = ctx.run(ctx.on.config_changed(), state=state)
-    assert state_out.unit_status.name == "blocked"
+    state = State(config={"prometheus_config_file": "",
+                           "config_file": EXAMPLE_SIMPLE_CONFIG,
+                           #"scripts_archive": EXAMPLE_B64_COMPRESSED_SCRIPTS
+                           "script_file": EXAMPLE_SIMPLE_SCRIPT
+                           })
+    with patch("charm.ScriptExporterCharm._create_systemd_service", MagicMock(return_value=None)):
+      state_out = ctx.run(ctx.on.config_changed(), state=state)
+      assert state_out.unit_status.name == "active"
 
 
 def test_cos_agent_relation_data_is_set_script_file(ctx):


### PR DESCRIPTION
Fixes #50.

This change makes `prometheus_config_file` optional and the workload doesn't go into `Blocked` if the value is unset. The unit test is updated to test this change.

To test the change, deploy the bundle:
```yaml
default-base: ubuntu@24.04/stable
applications:
  se:
    charm: local:script-exporter-0
    options:
      config_file: |
        scripts:
          - name: example
            command: /etc/script-exporter-script
  ubuntu:
    charm: ubuntu
    channel: latest/stable
    revision: 26
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "0":
    constraints: arch=amd64
relations:
- - ubuntu:juju-info
  - se:juju-info

```