### PR TITLE
chore: bump script_exporter from v2.15.1 to v3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The script-exporter is a subordinate charm; relating it to a *principal* over **
     ```yaml
     scripts:
       - name: hello # Name of the script, arbitrary
-        command: /etc/script-exporter-script # any available shell command, or `/etc/script-exporter-script` for the custom one
+        command:
+          - /etc/script-exporter/scripts/script-exporter-script # path to any available shell command, or the custom script path
         args:
           - argument # args to pass to the script
     ```
@@ -60,7 +61,6 @@ The script-exporter is a subordinate charm; relating it to a *principal* over **
         metrics_path: /probe
         params:
           script: [hello] # the name of the script as specified in the *config_file*
-          prefix: [script] # a custom prefix for this metric
         static_configs:
           - targets:
             - 127.0.0.1
@@ -113,12 +113,14 @@ The script-exporter is a subordinate charm; relating it to a *principal* over **
     ```yaml
     scripts:
       - name: hello
-        command: script1.sh
+        command:
+          - script1.sh
         args:
           - diego
 
       - name: bye
-        command: subdir/script2.sh
+        command:
+          - subdir/script2.sh
         args:
           - maradona
     ```
@@ -138,7 +140,6 @@ The script-exporter is a subordinate charm; relating it to a *principal* over **
         metrics_path: /probe
         params:
           script: [hello]
-          prefix: [script]
         static_configs:
           - targets:
             - 127.0.0.1
@@ -147,7 +148,6 @@ The script-exporter is a subordinate charm; relating it to a *principal* over **
         metrics_path: /probe
         params:
           script: [bye]
-          prefix: [script]
         static_configs:
           - targets:
             - 127.0.0.1

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -35,10 +35,10 @@ parts:
 
   script-exporter-binary:
     plugin: dump
-    source: https://github.com/ricoberger/script_exporter/releases/download/v2.15.1/script_exporter-linux-${CRAFT_ARCH_BUILD_FOR}
-    source-type: file
+    source: https://github.com/ricoberger/script_exporter/releases/download/v3.2.0/script_exporter-linux-${CRAFT_ARCH_BUILD_FOR}.tar.gz
+    source-type: tar
     permissions:
-      - path: script_exporter-linux-${CRAFT_ARCH_BUILD_FOR}
+      - path: script_exporter
         mode: "755"
 
 provides:

--- a/src/charm.py
+++ b/src/charm.py
@@ -160,8 +160,7 @@ class ScriptExporterCharm(ops.CharmBase):
         scripts_def = conf_dict.get("scripts", [])
 
         for definition in scripts_def:
-            command = definition.get("command", [])
-            if not command:
+            if not command := definition.get("command", []):
                 continue
 
             executable = command[0]

--- a/src/charm.py
+++ b/src/charm.py
@@ -160,7 +160,7 @@ class ScriptExporterCharm(ops.CharmBase):
         scripts_def = conf_dict.get("scripts", [])
 
         for definition in scripts_def:
-            if not command := definition.get("command", []):
+            if not (command := definition.get("command", [])):
                 continue
 
             executable = command[0]

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,6 @@ import base64
 import io
 import logging
 import os
-import platform
 import shutil
 import tarfile
 import textwrap
@@ -33,12 +32,6 @@ logger = logging.getLogger(__name__)
 
 EXPORTER_PORT = 9469
 
-
-ARCH = platform.machine()
-if platform.machine() == "x86_64":
-    ARCH = "amd64"
-elif platform.machine() in ("aarch64", "armv8b", "armv8l"):
-    ARCH = "arm64"
 
 SERVICE_FILENAME = "script-exporter.service"
 
@@ -115,7 +108,7 @@ class ScriptExporterCharm(ops.CharmBase):
 
     def _ensure_binary(self) -> None:
         # Make sure the exporter binary is present with a systemd service
-        shutil.copy("script_exporter-linux-{}".format(ARCH), self._binary_path)
+        shutil.copy("script_exporter", self._binary_path)
         os.chmod(self._binary_path, 0o755)
         logger.info(
             "Script Exporter binary installed from packaged files: %s", self._binary_path
@@ -167,8 +160,14 @@ class ScriptExporterCharm(ops.CharmBase):
         scripts_def = conf_dict.get("scripts", [])
 
         for definition in scripts_def:
-            if definition.get("command", "") not in self._script_names:
-                msg = f"{definition.get('command', '')} is not part of the uploaded scripts"
+            command = definition.get("command", [])
+            if not command:
+                continue
+
+            executable = command[0]
+
+            if executable not in self._script_names:
+                msg = f"{executable} is not part of the uploaded scripts"
                 logger.debug(msg)
                 continue
 
@@ -176,7 +175,7 @@ class ScriptExporterCharm(ops.CharmBase):
                 continue
 
             # Add prefix if the root is relative but keep as is if absolute.
-            definition["command"] = os.path.join(self._scripts_dir_path, definition["command"])
+            command[0] = os.path.join(self._scripts_dir_path, executable)
 
         return yaml.dump(conf_dict)
 
@@ -262,7 +261,7 @@ class ScriptExporterCharm(ops.CharmBase):
             [Service]
             LimitNPROC=infinity
             LimitNOFILE=infinity
-            ExecStart={self._binary_path} --config.file={self._config_path}
+            ExecStart={self._binary_path} --config.files={self._config_path}
             Restart=always
 
             [Install]

--- a/tests/integration/config_file.yaml
+++ b/tests/integration/config_file.yaml
@@ -1,5 +1,6 @@
 scripts:
   - name: hello
-    command: /etc/script-exporter-script
+    command:
+      - /etc/script-exporter-script
     args:
       - argument

--- a/tests/integration/config_multiple.yaml
+++ b/tests/integration/config_multiple.yaml
@@ -1,15 +1,18 @@
 scripts:
   - name: hello
-    command: script1.sh
+    command:
+      - script1.sh
     args:
       - diego
 
   - name: bye
-    command: subdir/script2.sh
+    command:
+      - subdir/script2.sh
     args:
       - maradona
 
   - name: abspath
-    command: /usr/bin/echo
+    command:
+      - /usr/bin/echo
     args:
       - 'champion{param="me"} 1'

--- a/tests/integration/prometheus_config_file.yaml
+++ b/tests/integration/prometheus_config_file.yaml
@@ -3,7 +3,6 @@ scrape_configs:
     metrics_path: /probe
     params:
       script: [hello]
-      prefix: [script]
     static_configs:
       - targets:
         - 127.0.0.1

--- a/tests/integration/prometheus_config_multiple.yaml
+++ b/tests/integration/prometheus_config_multiple.yaml
@@ -3,7 +3,6 @@ scrape_configs:
     metrics_path: /probe
     params:
       script: [hello]
-      prefix: [script]
     static_configs:
       - targets:
         - 127.0.0.1
@@ -12,7 +11,6 @@ scrape_configs:
     metrics_path: /probe
     params:
       script: [bye]
-      prefix: [script]
     static_configs:
       - targets:
         - 127.0.0.1
@@ -21,7 +19,6 @@ scrape_configs:
     metrics_path: /probe
     params:
       script: [abspath]
-      prefix: [script]
     static_configs:
       - targets:
         - 127.0.0.1

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,8 @@ exit $?
 
 EXAMPLE_SIMPLE_CONFIG = """scripts:
   - name: ping
-    command: /etc/script
+    command:
+      - /etc/script
     args:
       - 127.0.0.1
 """
@@ -21,7 +22,6 @@ PROMETHEUS_SIMPLE_CONFIG = """scrape_configs:
     metrics_path: /probe
     params:
       script: [ping]
-      prefix: [script]
     static_configs:
       - targets:
         - 127.0.0.1
@@ -49,12 +49,14 @@ AAAAAMAfuQIhncIHACgAAA==
 
 EXAMPLE_MULTIPLE_CONFIG = """scripts:
   - name: hello
-    command: script1.sh
+    command:
+      - script1.sh
     args:
       - diego
 
   - name: bye
-    command: script2.sh
+    command:
+      - script2.sh
     args:
       - maradona
 """
@@ -64,7 +66,6 @@ PROMETHEUS_MULTIPLE_CONFIG = """scrape_configs:
     metrics_path: /probe
     params:
       script: [hello]
-      prefix: [script]
     static_configs:
       - targets:
         - 127.0.0.1
@@ -73,7 +74,6 @@ PROMETHEUS_MULTIPLE_CONFIG = """scrape_configs:
     metrics_path: /probe
     params:
       script: [bye]
-      prefix: [script]
     static_configs:
       - targets:
         - 127.0.0.1


### PR DESCRIPTION
## Summary

Bumps the bundled [script_exporter](https://github.com/ricoberger/script_exporter) binary from **v2.15.1** to **v3.2.0**. All upstream breaking changes were introduced in v3.0.0; v3.1.0 and v3.2.0 are additive only.

---

## ⚠️ User-Facing Breaking Changes

These changes **affect charm users** who provide custom `config_file` or `prometheus_config_file` values. Existing configurations will need to be updated.

### 1. `command` field is now a list of strings

The `command` field in script configuration changed from a single string to a list:

```yaml
# Before (v2)
scripts:
  - name: ping
    command: /usr/bin/ping

# After (v3)
scripts:
  - name: ping
    command:
      - /usr/bin/ping
```

### 2. `prefix` parameter removed

The `prefix` URL parameter in Prometheus scrape configurations is no longer supported. Metrics from scripts **cannot be prefixed** anymore. Remove any `prefix` params:

```yaml
# Before (v2)
params:
  script: [test]
  prefix: [my_prefix]    # ← remove this line

# After (v3)
params:
  script: [test]
```

### 3. `ignoreOutputOnFail` replaced by `output` section

```yaml
# Before (v2)
ignoreOutputOnFail: true

# After (v3)
output:
  ignore_on_error: true
```

### 4. `cacheDuration` replaced by `cache` section

```yaml
# Before (v2)
cacheDuration: 60s

# After (v3)
cache:
  duration: 60.0    # float seconds, not a duration string
```

### 5. `allowEnvOverwrite` renamed to `allow_env_overwrite`

### 6. Auth config removed from YAML

`tls`, `basicAuth`, and `bearerAuth` top-level config sections no longer exist. TLS/auth is now configured via the Prometheus Exporter Toolkit `--web.config.file` flag. Users who had these in their config files will need to migrate.

### 7. Stricter output parsing

Script output is now validated using `prometheus/common/expfmt`. Scripts that previously emitted malformed metrics that happened to be accepted may now have those metrics rejected.

### 8. Metrics changes

- `script_use_cache` and `script_use_expired_cache` metrics **removed**, replaced by `script_cached`
- `/metrics` endpoint now exposes new exporter-level metrics (`script_exporter_http_requests_total`, etc.)

---

## 🔧 Changes Handled by the Charm (Non-Breaking for Users)

These upstream changes are **fully abstracted by the charm** — users do not need to take any action for these.

| Change | What the charm does |
|---|---|
| Binary packaging changed from raw file to `.tar.gz` | `charmcraft.yaml` updated: `source-type: tar`, new URL |
| Binary inside tarball renamed to `script_exporter` | `_ensure_binary()` copies the new filename |
| CLI flag `-config.file` → `--config.files` | Systemd service template updated |
| Discovery config removed from YAML | Charm never used it |
| `scripts_configs` removed | Charm uses single config file |
| Docker image moved to GHCR | Charm uses binary, not Docker |

---

## ✨ New Features Available (v3.1.0 + v3.2.0)

These are additive features that become available with this upgrade:

- **Configuration reload** — Config can be reloaded via `SIGHUP` or `POST /-/reload`, with configurable `--config.reload-interval`
- **Multiple config files** — `--config.files` supports glob patterns
- **Config validation** — `--config.check` flag to validate and exit
- **Nagios output format** — Scripts can output Nagios plugin format (`output.format: nagios`)
- **Config from URL** — Configuration files can be loaded from HTTP(S) URLs
- **Grafana Alloy module** — Native Grafana Alloy integration module
- **TLS/auth via exporter-toolkit** — Standard Prometheus TLS and auth support via `--web.config.file`
- **Script argument restriction** — `--script.no-args` to prevent scripts from accepting arguments
- **Repeatable listen addresses** — Multiple `--web.listen-address` flags

---

## Files Changed

| File | Change |
|---|---|
| `charmcraft.yaml` | Binary source → v3.2.0 tar.gz, `source-type: tar`, permissions path |
| `src/charm.py` | Binary name, `--config.files` flag, `command` as list handling, removed `ARCH` |
| `tests/integration/config_file.yaml` | `command` → list format |
| `tests/integration/config_multiple.yaml` | `command` → list format |
| `tests/integration/prometheus_config_file.yaml` | Removed `prefix` param |
| `tests/integration/prometheus_config_multiple.yaml` | Removed `prefix` params |
| `tests/unit/test_charm.py` | Updated config strings for v3 format |
